### PR TITLE
tests: add test_database & improve test_project

### DIFF
--- a/tests/cmag/database/test_database.py
+++ b/tests/cmag/database/test_database.py
@@ -1,0 +1,78 @@
+import pytest
+from peewee import *
+
+from cmag.database import CMagDatabase
+from cmag.database.base_model import CMagBaseModel
+
+@pytest.fixture
+def db_path(tmp_path):
+    db_path = tmp_path / 'database.db'
+    return db_path
+
+@pytest.fixture
+def cmag_db(db_path):
+    return CMagDatabase(db_path)
+
+class CMagTestModel(CMagBaseModel):
+    id = IntegerField(primary_key=True)
+    name = CharField(unique=True)
+
+class Test00CMagDatabaseInit:
+
+    def test00_init(self, db_path):
+        cmag_db = CMagDatabase(db_path)
+        assert isinstance(cmag_db, CMagDatabase)
+        assert isinstance(cmag_db.database, SqliteDatabase)
+        with cmag_db.database as database:
+            CMagTestModel.create_table()
+        assert db_path.exists() is True
+
+    def test00_init_not_file_path(self, tmp_path):
+        assert tmp_path.is_dir() is True
+        with pytest.raises(Exception):
+            cmag_db = CMagDatabase(tmp_path)
+            # CMagTestModel.create_table() -> peewee.OperationalError: unable to open database file
+
+    def test00_init_doubly_open(self, cmag_db):
+        cmag_db.open()
+
+    def test00_init_doubly_close(self, db_path):
+        cmag_db = CMagDatabase(db_path)
+        cmag_db.close()
+        cmag_db.close()
+
+# almost like peewee test...
+class Test01CMagDatabaseCRUD:
+    def test01_crud_simple_crud(self, cmag_db):
+        with cmag_db.database as database:
+            CMagTestModel.create_table()
+            CMagTestModel.create(name='foo').save()
+            CMagTestModel.create(name='bar').save()
+
+            assert CMagTestModel.get(id=1).id == 1
+            assert CMagTestModel.get(id=1).name == 'foo'
+            assert CMagTestModel.get(id=2).id == 2
+            assert CMagTestModel.get(id=2).name == 'bar'
+
+            CMagTestModel.get(id=1).update(name='baz')
+            CMagTestModel.get(id=2).delete()
+
+    def test01_crud_doubly_create(self, cmag_db):
+        with cmag_db.database as database:
+            CMagTestModel.create_table()
+            CMagTestModel.create(name="foo").save()
+            with pytest.raises(IntegrityError):
+                CMagTestModel.create(name="foo")
+
+    def test01_crud_read_dosent_exist(self, cmag_db):
+        with cmag_db.database as database:
+            CMagTestModel.create_table()
+            with pytest.raises(Exception):
+                CMagTestModel.get(id=1)
+
+    def test01_curd_doubly_delete(self, cmag_db):
+        with cmag_db.database as database:
+            CMagTestModel.create_table()
+            CMagTestModel.create(name="foo").save()
+            CMagTestModel.get(id=1).delete()
+            CMagTestModel.get(id=1).delete()

--- a/tests/cmag/project/test_project.py
+++ b/tests/cmag/project/test_project.py
@@ -1,14 +1,44 @@
-
-# from cmag.database import CMagDatabase
-# from cmag.challenge import CMagChallenge
-# from cmag.challenge.manager import CMagChallengeManager
-# from cmag.plugin.manager import CMagPluginManager
+import pytest
 
 from cmag.project import CMagProject
+from cmag.database import CMagDatabase
+from cmag.challenge.manager import CMagChallengeManager, CMagChallenge
+from cmag.plugin.manager import CMagPluginManager
 
-# import pytest
+class Test00CMagProjectInit:
+    def test00_init(self, tmp_path):
+        assert tmp_path.is_dir() is True
+        assert tmp_path.exists() is True
+        project = CMagProject(tmp_path)
+        assert project.path.exists() is True
 
-def test_CMagProject():
-    test_dir = "/tmp/project"
-    project = CMagProject(test_dir)
-    assert project != None
+    def test00_init_not_exist(self, tmp_path):
+        not_exist_tmp_path = tmp_path / "not_exist"
+        assert not_exist_tmp_path.exists() is False
+        project = CMagProject(not_exist_tmp_path)
+        assert project.path.exists() is True
+
+    def test00_init_empty_string(self):
+        empty_string = ""
+        # this makes project directory at "."
+        project = CMagProject(empty_string)
+        assert project.path.exists() is True
+
+
+class Test01ProjectDB:
+    def test01_db_isinstance(self, tmp_path):
+        project = CMagProject(tmp_path)
+        assert isinstance(project.db, CMagDatabase) is True
+        assert (project.path / "project.db").is_file() is True
+
+@pytest.fixture
+def project(tmp_path):
+    return CMagProject(tmp_path)
+
+class Test02ProjectChallengeManager:
+    def test02_challenge_manager_isinstance(self, project):
+        assert isinstance(project.challenge_manager, CMagChallengeManager) is True
+
+    def test02_challenge_manager_add_get(self, project):
+        assert isinstance(project.add_challenge('foo'), CMagChallenge) is True
+        assert project.get_challenge_by_id(1).id == project.get_challenge_by_name('foo').id


### PR DESCRIPTION
================================================================================================== FAILURES ===================================================================================================
______________________________________________________________________________ Test00CMagDatabaseInit.test00_init_not_file_path _______________________________________________________________________________

self = <tests.cmag.database.test_database.Test00CMagDatabaseInit object at 0x7fe8a2221be0>
tmp_path = PosixPath('/private/var/folders/js/cdd9wzmd7b1ffgbmjyjk3dqc0000gp/T/pytest-of-kiddo/pytest-304/test00_init_not_file_path0')

    def test00_init_not_file_path(self, tmp_path):
        assert tmp_path.is_dir() is True
        with pytest.raises(Exception):
>           cmag_db = CMagDatabase(tmp_path)
E           Failed: DID NOT RAISE <class 'Exception'>

cmag/database/test_database.py:33: Failed
=========================================================================================== short test summary info ===========================================================================================
FAILED cmag/database/test_database.py::Test00CMagDatabaseInit::test00_init_not_file_path - Failed: DID NOT RAISE <class 'Exception'>
======================================================================================== 1 failed, 13 passed in 0.28s =========================================================================================

CMagDatabase에 db 파일이 아닌 디렉토리로 인자를 줘도 예외처리를 하지 않고 이후 peewee에서 터집니다. Exception과 관련해서 구조가 정해지지 않아 tests에만 반영하고 코드를 수정하지 않았습니다.