### PR TITLE
Add exception handler

### DIFF
--- a/cmag/challenge/challenge.py
+++ b/cmag/challenge/challenge.py
@@ -4,9 +4,11 @@ if typing.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
 
 from cmag.challenge.challenge_impl import CMagChallengeImpl
+from .exceptions import CMagChallListError, Exception, CMagChallInitError, CMagChallCreateError, CMagChallAddError, CMagChallGetByPathError, CMagChallGetError, CMagChallRemoveError
 
 class CMagChallenge(CMagChallengeImpl):
-
+    
+    @Exception(CMagChallInitError)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -21,20 +23,26 @@ class CMagChallenge(CMagChallengeImpl):
     def description(self) -> str:
         return self.record.name
 
+    @Exception(CMagChallCreateError)
     def create_file(self, *args, **kwargs):
         return self.file_manager.create_file(*args, **kwargs)
 
+    @Exception(CMagChallAddError)
     def add_file(self, *args, **kwargs):
         return self.file_manager.add_file(*args, **kwargs)
 
+    @Exception(CMagChallGetError)
     def get_file(self, *args, **kwargs):
         return self.file_manager.get_file(*args, **kwargs)
 
+    @Exception(CMagChallGetByPathError)
     def get_file_by_path(self, *args, **kwargs):
         return self.file_manager.get_file_by_path(*args, **kwargs)
 
+    @Exception(CMagChallListError)
     def list_files(self, *args, **kwargs):
         return self.file_manager.list_files(*args, **kwargs)
 
+    @Exception(CMagChallRemoveError)
     def remove_file(self, *args, **kwargs):
         return self.file_manager.remove_file(*args, **kwargs)

--- a/cmag/challenge/challenge.py
+++ b/cmag/challenge/challenge.py
@@ -4,11 +4,11 @@ if typing.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
 
 from cmag.challenge.challenge_impl import CMagChallengeImpl
-from .exceptions import CMagChallListError, Exception, CMagChallInitError, CMagChallCreateError, CMagChallAddError, CMagChallGetByPathError, CMagChallGetError, CMagChallRemoveError
+from .exceptions import raise_except_decorate, CMagChallListError, CMagChallInitError, CMagChallCreateError, CMagChallAddError, CMagChallGetByPathError, CMagChallGetError, CMagChallRemoveError
 
 class CMagChallenge(CMagChallengeImpl):
     
-    @Exception(CMagChallInitError)
+    @raise_except_decorate(CMagChallInitError)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -23,26 +23,26 @@ class CMagChallenge(CMagChallengeImpl):
     def description(self) -> str:
         return self.record.name
 
-    @Exception(CMagChallCreateError)
+    @raise_except_decorate(CMagChallCreateError)
     def create_file(self, *args, **kwargs):
         return self.file_manager.create_file(*args, **kwargs)
 
-    @Exception(CMagChallAddError)
+    @raise_except_decorate(CMagChallAddError)
     def add_file(self, *args, **kwargs):
         return self.file_manager.add_file(*args, **kwargs)
 
-    @Exception(CMagChallGetError)
+    @raise_except_decorate(CMagChallGetError)
     def get_file(self, *args, **kwargs):
         return self.file_manager.get_file(*args, **kwargs)
 
-    @Exception(CMagChallGetByPathError)
+    @raise_except_decorate(CMagChallGetByPathError)
     def get_file_by_path(self, *args, **kwargs):
         return self.file_manager.get_file_by_path(*args, **kwargs)
 
-    @Exception(CMagChallListError)
+    @raise_except_decorate(CMagChallListError)
     def list_files(self, *args, **kwargs):
         return self.file_manager.list_files(*args, **kwargs)
 
-    @Exception(CMagChallRemoveError)
+    @raise_except_decorate(CMagChallRemoveError)
     def remove_file(self, *args, **kwargs):
         return self.file_manager.remove_file(*args, **kwargs)

--- a/cmag/challenge/exceptions.py
+++ b/cmag/challenge/exceptions.py
@@ -65,12 +65,23 @@ class CMagChallMgrDeleteError(CMagChallMgrFailed): ...
 class CMagChallModelError(CMagChallModelFailed): ...
 
 # Exception raise decorator
-def Exception(exception):
+def raise_except_decorate(exception):
     def decorator(function):
         def wrapper(self, *args, **kwargs):
             try:
                 return function(self, *args, **kwargs)
             except:
                 raise exception
+        return wrapper
+    return decorator
+
+# Exception handler decorator
+def handle_except_decorate(handler):
+    def decorator(function):
+        def wrapper(self, *args, **kwargs):
+            try:
+                return function(self, *args, **kwargs)
+            except Exception as e:
+                return handler(self, e)
         return wrapper
     return decorator

--- a/cmag/challenge/exceptions.py
+++ b/cmag/challenge/exceptions.py
@@ -1,31 +1,76 @@
-# base dummy class
-class ChallengeFailed(Exception):
-    pass
+# base of challenge module
+class ChallFailed(Exception):
+    def __str__(self) -> str:
+        return f'ChallFailed'
 
 # class of challenge_impl.py
-class CMagChallengeImplFailed(ChallengeFailed):
-    pass
+class CMagChallImplFailed(ChallFailed):
+    def __str__(self) -> str:
+        return f'CMagChallImplFailed'
 
 # class of challenge.py
-class CMagChallengeFailed(CMagChallengeImplFailed):
-    pass
+class CMagChallFailed(CMagChallImplFailed):
+    def __str__(self) -> str:
+        return f'CMagChallFailed'
+
+# class of manager_impl.py
+class CMagChallMgrImplFailed(ChallFailed):
+    def __str__(self) -> str:
+        return f'CMagChallMgrImplFailed'
 
 # class of manager.py
-class CMagChallengeMangerFailed(ChallengeFailed):
-    pass
+class CMagChallMgrFailed(CMagChallMgrImplFailed):
+    def __str__(self) -> str:
+        return f'CMagChallMgrFailed'
 
 # class of model.py
-class CMagChallengeModelFailed(ChallengeFailed):
-    pass
+class CMagChallModelFailed(ChallFailed):
+    def __str__(self) -> str:
+        return f'CMagChallModelFailed'
 
-class CMagChallengeImplCreateError(CMagChallengeImplFailed): ...
-class CMagChallengeImplGetError(CMagChallengeImplFailed): ...
-class CMagChallengeImplSelectError(CMagChallengeImplFailed): ...
-class CMagChallengeImplDeleteError(CMagChallengeImplFailed): ...
+# CMagChallengeImpl class
+class CMagChallImplInitError(CMagChallImplFailed): 
+    def __str__(self) -> str:
+        return f'CMagChallImplInitError'
 
-class CMagChallengeManagerCreateError(CMagChallengeMangerFailed): ...
-class CMagChallengeManagerGetError(CMagChallengeMangerFailed): ...
-class CMagChallengeManagerSelectError(CMagChallengeMangerFailed): ...
-class CMagChallengeManagerDeleteError(CMagChallengeMangerFailed): ...
+class CMagChallImplRecordError(CMagChallImplFailed):
+    def __str__(self) -> str:
+        return f'CMagChallImplRecordError'
 
-class CMagChallengeModelError(CMagChallengeModelFailed): ...
+# CMagChallenge class
+class CMagChallInitError(CMagChallFailed): ...
+class CMagChallCreateError(CMagChallFailed): ...
+class CMagChallAddError(CMagChallFailed): ...
+class CMagChallGetError(CMagChallFailed): ...
+class CMagChallGetByPathError(CMagChallFailed): ...
+class CMagChallListError(CMagChallFailed): ...
+class CMagChallRemoveError(CMagChallFailed): ...
+
+# CMagChallengeManagerImpl class
+class CMagChallMgrImplInitError(CMagChallMgrImplFailed): ...
+class CMagChallMgrImplCreateError(CMagChallMgrImplFailed): 
+    def __str__(self) -> str:
+        return f'CMagChallMgrImplCreateError'
+class CMagChallMgrImplGetError(CMagChallMgrImplFailed): ...
+class CMagChallMgrImplGetByIdError(CMagChallMgrImplFailed): ...
+class CMagChallMgrImplSelectError(CMagChallMgrImplFailed): ...
+
+# CMagChallengeManager class
+class CMagChallMgrCreateError(CMagChallMgrFailed): ...
+class CMagChallMgrGetError(CMagChallMgrFailed): ...
+class CMagChallMgrSelectError(CMagChallMgrFailed): ...
+class CMagChallMgrDeleteError(CMagChallMgrFailed): ...
+
+# CMagChallengeModel class
+class CMagChallModelError(CMagChallModelFailed): ...
+
+# Exception raise decorator
+def Exception(exception):
+    def decorator(function):
+        def wrapper(self, *args, **kwargs):
+            try:
+                return function(self, *args, **kwargs)
+            except:
+                raise exception
+        return wrapper
+    return decorator

--- a/cmag/challenge/manager.py
+++ b/cmag/challenge/manager.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 import typing
 
+from cmag.challenge.exceptions import CMagChallFailed, CMagChallImplFailed, CMagChallMgrImplFailed, CMagChallModelFailed
+
 if typing.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
+    from cmag.project import CMagProject
 
 import peewee
 from cmag.challenge.manager_impl import CMagChallengeManagerImpl
@@ -21,11 +24,22 @@ class CMagChallengeManager(CMagChallengeManagerImpl):
                 self.log.error(f"failed to create challenge record: {name}")
                 return None
 
+            return CMagChallenge(self.project, record.id)
         except peewee.IntegrityError:
             self.log.error(f"challenge {name} exists.")
-            return None
-
-        return CMagChallenge(self.project, record.id)
+        except CMagChallMgrImplFailed as e:
+            self.log.error(e)
+            # TODO: do something
+        except CMagChallFailed as e:
+            self.log.error(e)
+            # TODO: do something
+        except CMagChallImplFailed as e:
+            self.log.error(e)
+            # TODO: do something
+        except CMagChallModelFailed as e:
+            self.log.error(e)
+            # TODO: do something
+        return None
 
     def get_challenge(self, id: int) -> Optional[CMagChallenge]:
 

--- a/cmag/challenge/manager.py
+++ b/cmag/challenge/manager.py
@@ -11,7 +11,7 @@ import peewee
 from cmag.challenge.manager_impl import CMagChallengeManagerImpl
 from cmag.challenge.model import CMagChallengeModel
 from cmag.challenge.challenge import CMagChallenge
-from .exceptions import handle_except_decorate
+from .exceptions import CMagChallMgrFailed, handle_except_decorate
 
 class CMagChallengeManager(CMagChallengeManagerImpl):
 
@@ -19,17 +19,23 @@ class CMagChallengeManager(CMagChallengeManagerImpl):
         return f"<CMagChallengeManager challenges={len(self.list_challenges())}>"
 
     def handle_exception(self, e):
-        # TODO:
-        if e is peewee.IntegrityError:
+        # TODO: handle exception at challenge layer
+        error = e.__class__
+        if issubclass(error, peewee.IntegrityError):
             self.log.error(f"challenge file already exists.")
-        elif e is CMagChallMgrImplFailed:
+            raise CMagChallMgrFailed
+        elif issubclass(error, CMagChallMgrImplFailed):
             self.log.error(e)
-        elif e is CMagChallFailed:
+            raise CMagChallMgrFailed
+        elif issubclass(error, CMagChallFailed):
             self.log.error(e)
-        elif e is CMagChallImplFailed:
+            raise CMagChallMgrFailed
+        elif issubclass(error, CMagChallImplFailed):
             self.log.error(e)
-        elif e is CMagChallModelFailed:
+            raise CMagChallMgrFailed
+        elif issubclass(error, CMagChallModelFailed):
             self.log.error(e)
+            raise CMagChallMgrFailed
 
     @handle_except_decorate(handle_exception)
     def add_challenge(self, name: str) -> Optional[CMagChallenge]:

--- a/cmag/challenge/manager_impl.py
+++ b/cmag/challenge/manager_impl.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 import typing
 
-from cmag.challenge.exceptions import CMagChallMgrImplSelectError
-
 if typing.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
     from logging import Logger
@@ -11,11 +9,11 @@ if typing.TYPE_CHECKING:
 
 import peewee
 from cmag.challenge.model import CMagChallengeModel
-from .exceptions import Exception, CMagChallMgrImplInitError, CMagChallMgrImplCreateError, CMagChallMgrImplGetError, CMagChallMgrImplGetByIdError, CMagChallMgrImplSelectError
+from .exceptions import raise_except_decorate, CMagChallMgrImplInitError, CMagChallMgrImplCreateError, CMagChallMgrImplGetError, CMagChallMgrImplGetByIdError, CMagChallMgrImplSelectError
 
 class CMagChallengeManagerImpl:
 
-    @Exception(CMagChallMgrImplInitError)
+    @raise_except_decorate(CMagChallMgrImplInitError)
     def __init__(self, project: CMagProject):
         self._project = project
         self._log = project.logger.create_logger('challenge_manager')
@@ -34,22 +32,22 @@ class CMagChallengeManagerImpl:
 
     # database queries
 
-    @Exception(CMagChallMgrImplCreateError)
+    @raise_except_decorate(CMagChallMgrImplCreateError)
     def create_challenge_record(self, **query) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.create(**query)
 
-    @Exception(CMagChallMgrImplGetError)
+    @raise_except_decorate(CMagChallMgrImplGetError)
     def get_challenge_record(self, *query, **filters) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.get(*query, **filters)
 
-    @Exception(CMagChallMgrImplGetByIdError)
+    @raise_except_decorate(CMagChallMgrImplGetByIdError)
     def get_challenge_record_by_id(self, id: int) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.get_by_id(id)
 
-    @Exception(CMagChallMgrImplSelectError)
+    @raise_except_decorate(CMagChallMgrImplSelectError)
     def select_challenge_records(self, *fields) -> peewee.ModelSelect:
         with self.project.db as database:
             return CMagChallengeModel.select(*fields)

--- a/cmag/challenge/manager_impl.py
+++ b/cmag/challenge/manager_impl.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import typing
 
+from cmag.challenge.exceptions import CMagChallMgrImplSelectError
+
 if typing.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
     from logging import Logger
@@ -9,9 +11,11 @@ if typing.TYPE_CHECKING:
 
 import peewee
 from cmag.challenge.model import CMagChallengeModel
+from .exceptions import Exception, CMagChallMgrImplInitError, CMagChallMgrImplCreateError, CMagChallMgrImplGetError, CMagChallMgrImplGetByIdError, CMagChallMgrImplSelectError
 
 class CMagChallengeManagerImpl:
 
+    @Exception(CMagChallMgrImplInitError)
     def __init__(self, project: CMagProject):
         self._project = project
         self._log = project.logger.create_logger('challenge_manager')
@@ -30,18 +34,22 @@ class CMagChallengeManagerImpl:
 
     # database queries
 
+    @Exception(CMagChallMgrImplCreateError)
     def create_challenge_record(self, **query) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.create(**query)
 
+    @Exception(CMagChallMgrImplGetError)
     def get_challenge_record(self, *query, **filters) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.get(*query, **filters)
 
+    @Exception(CMagChallMgrImplGetByIdError)
     def get_challenge_record_by_id(self, id: int) -> CMagChallengeModel:
         with self.project.db as database:
             return CMagChallengeModel.get_by_id(id)
 
+    @Exception(CMagChallMgrImplSelectError)
     def select_challenge_records(self, *fields) -> peewee.ModelSelect:
         with self.project.db as database:
             return CMagChallengeModel.select(*fields)
@@ -59,4 +67,3 @@ class CMagChallengeManagerImpl:
             return self.get_challenge_record_by_id(id)
         except peewee.DoesNotExist:
             return None
-

--- a/cmag/interface/command/challenge_handler.py
+++ b/cmag/interface/command/challenge_handler.py
@@ -1,7 +1,11 @@
 from argparse import ArgumentParser, _SubParsersAction, Namespace
 from pathlib import Path
+
+from cmag.project.exceptions import ProjectFailed
+from cmag.challenge.exceptions import ChallFailed
 from .utils import open_project, open_challenge
 
+import logging
 
 # challenge ... {subcommand}
 
@@ -18,10 +22,12 @@ def challenge_argparse(parser: ArgumentParser):
 # challenge ... add ...
 
 def challenge_add_handler(args):
-    project = open_project(args)
-    challenge = project.challenge_manager.add_challenge(args.name)
-    if not challenge:
-        print("failed.")
+    try:
+        project = open_project(args)
+        challenge = project.challenge_manager.add_challenge(args.name)
+    except (ProjectFailed, ChallFailed) as e:
+        logging.exception(e)
+        print("failed")
     else:
         print("done.")
 


### PR DESCRIPTION
일단 challenge에 대해서 이런 느낌으로 exception 처리를 해봤습니다.

`challenge, challenge_impl, manager_impl` --(raise exception)-->  `manager` --(raise exception)-->  `interface.command.challenge_handler`

1. challenge, challenge_impl, manager_impl 클래스 내의 함수에서 exception 발생시 특정 exception raise (raise_except_decorate 데코레이터 사용) [code link](https://github.com/ch4rli3kop/ctf-magician/blob/953b87782d5f087062d97e4dc406b7620f398565/cmag/challenge/challenge.py#L11)
2. 해당 exception을 manager의 handle_exception 함수에서 처리(exception handler 전달을 위해 handle_except_decorate 데코레이터 사용). 상위 exception raise. [code link](https://github.com/ch4rli3kop/ctf-magician/blob/953b87782d5f087062d97e4dc406b7620f398565/cmag/challenge/manager.py#L21)
3. interface.command.challenge_handler에서 exception 처리. [code link](https://github.com/ch4rli3kop/ctf-magician/blob/953b87782d5f087062d97e4dc406b7620f398565/cmag/interface/command/challenge_handler.py#L28)

다음은 위와 같은 코드로 프로젝트가 생성되지 않은 상황에서 challenge를 추가했을 때 발생하는 logging.exception 예시입니다.
```shell
(cmag) -------------------------------------------------------------------------------------------------------
ch4rli3kop in [~/code_snippets/ctf-magician-fork] 16:26:46 › python3 ctf-magician.py cli -p ~/tmp/testproject2 challenge add test5
[WARNING:ctf-magician] no plugins loaded.
[ERROR:ctf-magician.challenge_manager] CMagChallMgrImplCreateError
ERROR:root:CMagChallMgrFailed
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 3221, in execute_sql
    cursor.execute(sql, params or ())
sqlite3.IntegrityError: UNIQUE constraint failed: cmagchallengemodel.name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/exceptions.py", line 72, in wrapper
    return function(self, *args, **kwargs)
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/manager_impl.py", line 38, in create_challenge_record
    return CMagChallengeModel.create(**query)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 6508, in create
    inst.save(force_insert=True)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 6718, in save
    pk = self.insert(**field_dict).execute()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 1946, in inner
    return method(self, database, *args, **kwargs)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 2017, in execute
    return self._execute(database)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 2822, in _execute
    return super(Insert, self)._execute(database)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 2535, in _execute
    cursor = database.execute(self)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 3234, in execute
    return self.execute_sql(sql, params, commit=commit)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 3218, in execute_sql
    with __exception_wrapper__:
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 2994, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 191, in reraise
    raise value.with_traceback(tb)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cmag/lib/python3.10/site-packages/peewee.py", line 3221, in execute_sql
    cursor.execute(sql, params or ())
peewee.IntegrityError: UNIQUE constraint failed: cmagchallengemodel.name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/exceptions.py", line 83, in wrapper
    return function(self, *args, **kwargs)
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/manager.py", line 43, in add_challenge
    if not (record := self.create_challenge_record(name=name)):
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/exceptions.py", line 74, in wrapper
    raise exception
cmag.challenge.exceptions.CMagChallMgrImplCreateError: CMagChallMgrImplCreateError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/interface/command/challenge_handler.py", line 27, in challenge_add_handler
    challenge = project.challenge_manager.add_challenge(args.name)
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/exceptions.py", line 85, in wrapper
    return handler(self, e)
  File "/Users/ch4rli3kop/code_snippets/ctf-magician-fork/cmag/challenge/manager.py", line 29, in handle_exception
    raise CMagChallMgrFailed
cmag.challenge.exceptions.CMagChallMgrFailed: CMagChallMgrFailed
failed
```